### PR TITLE
Excluding plans under site-modules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ require 'onceover/rake_tasks'
 
 PuppetSyntax.app_management = true
 PuppetSyntax.exclude_paths = ["site/**/plans/*"]
+PuppetSyntax.exclude_paths = ["site-modules/**/plans/*"]
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_140chars')


### PR DESCRIPTION
`site-modules` is the new standard directory name for local modules in the control repo.