### PR TITLE
Fixes #10 - Cleanup after package install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,14 @@ RUN rpm -i https://pm.puppet.com/cgi-bin/pdk_download.cgi?arch=x86_64\&dist=el\&
       libgcc \
       bash \
       wget \
-      ca-certificates
+      ca-certificates \
+    && yum clean all
 
 #Set up Ruby 2.4. Must be separate from Ruby installed with PDK
 RUN yum install -y centos-release-scl \
     && yum-config-manager --enable rhel-server-rhscl-7-rpms \
-    && yum install -y rh-ruby24 rh-ruby24-ruby-devel rh-git218
+    && yum install -y rh-ruby24 rh-ruby24-ruby-devel rh-git218 \
+    && yum clean all
 
 # Install dependent gems
 RUN gem install --no-ri --no-rdoc r10k \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,11 @@ RUN rpm -i https://pm.puppet.com/cgi-bin/pdk_download.cgi?arch=x86_64\&dist=el\&
       bash \
       wget \
       ca-certificates \
-    && yum clean all
-
-#Set up Ruby 2.4. Must be separate from Ruby installed with PDK
-RUN yum install -y centos-release-scl \
+      centos-release-scl \
     && yum-config-manager --enable rhel-server-rhscl-7-rpms \
     && yum install -y rh-ruby24 rh-ruby24-ruby-devel rh-git218 \
     && yum clean all
+#Set up Ruby 2.4. Must be separate from Ruby installed with PDK
 
 # Install dependent gems
 RUN gem install --no-ri --no-rdoc r10k \
@@ -45,8 +43,7 @@ RUN gem install --no-ri --no-rdoc r10k \
       puppet-lint \
       onceover \
       rest-client \
-      ra10ke \
-    && ln -s /usr/local/bundle/bin/* /usr/local/bin/
+      ra10ke
 
 COPY Rakefile /Rakefile
 


### PR DESCRIPTION
As per my comments in issue #10, this saves ~360MB.

```
$ docker images | grep puppet-dev-tools
tommythekid/puppet-dev-tools                                    latest                        9801083f16d7        23 hours ago        1.06GB
tommythekid/puppet-dev-tools                                    <none>                        4c270f1497a4        44 hours ago        1.1GB
puppet/puppet-dev-tools                                         latest                        02287227c5bf        13 days ago         1.42GB
```

NOTE: The untagged one in the middle is without the combined yum commands (~40MB)