### PR TITLE
Fix ra10ke tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,9 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "bundle/
 
 Rake::Task[:spec_prep].enhance [:generate_fixtures]
 
+# Pull in the ra10ke rake tasks
+Ra10ke::RakeTask.new
+
 desc "Run tests"
 task :run_tests do
   print "Executing Lint Test...\n"


### PR DESCRIPTION
Previous to this PR, the latest ra10ke gem was breaking Puppetfile syntax validation due to a change in the way the gem's rake tasks are loaded. This PR properly loads the rake tasks in the Rakefile so that the r10k::syntax task is restored.