### PR TITLE
add puppet-lint-security-plugins gem because *security*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN gem install --no-ri --no-rdoc r10k \
       rubocop \
       puppetlabs_spec_helper \
       puppet-lint \
+      puppet-lint-security-plugins \
       onceover \
       onceover-codequality \
       rest-client \


### PR DESCRIPTION
Add gem "puppet-lint-security-plugins" - used to identify security issues in Puppet code.  