### PR TITLE
Fix build of ffi / symlink mkdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -qq \
 RUN mkdir /setup
 WORKDIR /setup
 ADD Gemfile* /setup/
+RUN ln -s /bin/mkdir /usr/bin/mkdir
 RUN gem install bundler \
   && bundle config set system 'true' \
   && bundle install --jobs=3 \

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'ffi',                                                       '~> 1.12', '>= 1.12.2'
 gem 'hiera-eyaml',                                               '~> 3.2'
 gem 'json',                                                      '~> 2.3'
 gem 'nokogiri',                                                  '~> 1.10', '>= 1.10.9'


### PR DESCRIPTION
The ffi gem think mkdir should be in /usr/bin/mkdir when it is in fact located at /bin/mkdir. This commit creates a symlink from one to the other. It also adds the ffi gem to the Gemfile so that its native extensions are already built.