### PR TITLE
(DIO-679) Add tests for running linter

### DIFF
--- a/tests/control-repo/goodsyntax/manifests/site.pp
+++ b/tests/control-repo/goodsyntax/manifests/site.pp
@@ -27,7 +27,7 @@ File { backup => 'main' }
 
 Package { allow_virtual => false }
 
-if $::osfamily == 'windows' {
+if $facts['os']['family'] == 'windows' {
   File {
     source_permissions => ignore,
   }

--- a/tests/control-repo/goodsyntax/site/profile/manifests/common.pp
+++ b/tests/control-repo/goodsyntax/site/profile/manifests/common.pp
@@ -1,11 +1,12 @@
+# Common profile class
 class profile::common {
   include profile::pe_env
   include profile::firewall
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     default: { } # for OS's not listed, do nothing
-    "redhat": {
-      notify { "I found redhat": }
+    'redhat': {
+      notify { 'I found redhat': }
     }
   }
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -61,3 +61,6 @@ runtest 'Manifests with good syntax' "docker run -v `pwd`/control-repo/goodsynta
 
 runtest 'Hiera with bad syntax' "docker run -v `pwd`/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile syntax:hiera" 1 "ERROR: Failed to parse data/common.yaml: (data/common.yaml): could not find expected ':' while scanning a simple key at line 4 column 1";
 runtest 'Hiera with good syntax' "docker run -v `pwd`/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile syntax:hiera" 0 '';
+
+runtest 'Linting check catches errors' "docker run -v `pwd`/control-repo/badsyntax:/repo ${SHA} rake -f /Rakefile lint syntax yamllint" 1 'site/profile/manifests/common.pp - WARNING: legacy fact on line 5';
+runtest 'Linting check finds no errors' "docker run -v `pwd`/control-repo/goodsyntax:/repo ${SHA} rake -f /Rakefile lint syntax yamllint" 0 '';


### PR DESCRIPTION
This PR adds tests for the corresponding new linting check in the code validation CD4PE stage. The files in the `goodsyntax/` testing directory have also been updated to pass the check.