### PR TITLE
Added parallel 1.19.2 to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'json',                                                      '~> 2.3'
 gem 'nokogiri',                                                  '~> 1.10', '>= 1.10.9'
 gem 'onceover-codequality',                                      '~> 0.7'
 gem 'onceover',                                                  '~> 3.16'
+gem 'parallel',                                                  '~> 1.19.2'               
 gem 'puppet-lint-classes_and_types_beginning_with_digits-check', '~> 0.1'
 gem 'puppet-lint-leading_zero-check',                            '~> 0.1'
 gem 'puppet-lint-legacy_facts-check' # https://github.com/mmckinst/puppet-lint-legacy_facts-check/pull/33 aka v1.0.4 (not on rubygems yet)


### PR DESCRIPTION
It would be really useful if we could run onceover with the --parallel flag to run tests in parallel.
For customers in air gapped environments we need the gem to be included in the docker container.
I've added it to the Gemfile and tested by own build of the container and it allows onceover to run in parallel without needing internet access. 