### PR TITLE
Create rootless and root-based images

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -8,12 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Build image
+      - name: Build rootless image
+        run: ./build-rootless.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
+      - name: Build standard image
         run: ./build.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images
         run: |
+          docker tag puppet-dev-tools:latest-rootless ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)-rootless
           docker tag puppet-dev-tools:latest ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)
       - name: List Docker images
         run: docker images --filter "reference=puppet-dev-tools*" --filter "reference=*/puppet-dev-tools*"
@@ -24,4 +27,5 @@ jobs:
         run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
       - name: Push Docker images
         run: |
+          docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)-rootless
           docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Build image
+      - name: Build rootless image
+        run: ./build-rootless.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
+      - name: Build standard image
         run: ./build.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
       - name: Run tests
         run: cd tests; ./run_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,7 @@ RUN bundle config set system 'true' \
 
 WORKDIR /repo
 
+FROM base AS rootless
+
 FROM base AS main
+USER root

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## Docker Tags
 
 - `<year>-<month>-<day>-<a short string>`: Each merge to master generates an image tagged with the date of its build followed by a short git SHA. These images are suitable for pinning to if you do not wish to live on the edge with `4.x`. Changes from one image to the next will include things shown in the [commit history](https://github.com/puppetlabs/puppet-dev-tools/commits/master) on GitHub and updated operating system packages pulled in at build time. The latest version of the PDK is also pulled in at build time.
+- `<year>-<month>-<day>-<a short string>-rootless`: This is just like the tag above but the container runs as a user namecd `puppetdev`.
 - `4.x`: This the tag that is used in the 4.x versions of CD4PE. This tag is updated manually from time to time.
 - `latest`: This is not actually the build of `puppet-dev-tools`, but rather the latest build used in CD4PE < 4.0. These builds are manually created by the CD4PE team.
 

--- a/build-rootless.sh
+++ b/build-rootless.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+GH_USER=${1:-puppetlabs}
+DOCKER_IMAGE=${2:-'puppet-dev-tools:latest-rootless'}
+
+docker build \
+  --target rootless \
+  -t ${DOCKER_IMAGE} \
+  --build-arg VCS_REF=$(git rev-parse --short HEAD) \
+  --build-arg GH_USER=${GH_USER} \
+  -f Dockerfile .


### PR DESCRIPTION
The default output of the Dockerfile is still an image that runs as root, but now there is an option to produce one that runs as "puppetdev" instead. A second build script was added that outputs an image from before the build process switches back to root.