### PR TITLE
Fix apt package upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get install -y apt-utils \
+  && apt-get update -qq \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends curl libxml2-dev libxslt1-dev g++ gcc git gnupg2 make openssh-client ruby-dev wget zlib1g-dev \
   && wget https://apt.puppet.com/puppet-tools-release-buster.deb \


### PR DESCRIPTION
Previous to this PR, the apt cache was not updated prior to doing an apt package upgrade. This caused important updates to be missed. This commit introduces an initial apt cache update prior to doing an apt upgrade. Another apt cache update is one after the puppet agent repository package is installed.