### PR TITLE
(CDPE-4329) Github action to promote 4.x image

### DIFF
--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -1,0 +1,34 @@
+name: "Publish images to 4.x and 4.x-rootless tags"
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Image tag on dockerhub to promote to the puppet-dev-tools 4.x image tag (ie. 2021-06-29-da6666a)
+        required: true
+      image_tag_rootless:
+        description: Image tag on dockerhub to promote to the puppet-dev-tools 4.x-rootless image tag (ie. 2021-06-29-da6666a-rootless)
+        required: true
+
+jobs:
+  publish-4x-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
+      - name: Publish standard image to 4.x
+        env:
+          IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          docker pull ${IMAGE_BASE}:${IMAGE_TAG}
+          docker tag ${IMAGE_BASE}:${IMAGE_TAG} ${IMAGE_BASE}:4.x
+          docker push ${IMAGE_BASE}:4.x
+      - name: Publish rootless image to 4.x-rootless
+        env:
+          IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
+          IMAGE_TAG: ${{ github.event.inputs.image_tag_rootless }}
+        run: |
+          docker pull ${IMAGE_BASE}:${IMAGE_TAG}
+          docker tag ${IMAGE_BASE}:${IMAGE_TAG} ${IMAGE_BASE}:4.x-rootless
+          docker push ${IMAGE_BASE}:4.x-rootless


### PR DESCRIPTION
With this commit, we add a Github action to take a dev image (and
rootless dev image) and promote them to 4.x and 4.x-rootless,
respectively. This action is to be used by automation in the Pipelines
Infra repo to promote test images to the 4.x tag before each release
in order to release puppet-dev-tools monthly. See
https://tickets.puppetlabs.com/browse/CDPE-4314 for more details.