### PR TITLE
(CDPE-4810) Remove sensitive test files per customer request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,3 +73,9 @@ FROM base AS rootless
 
 FROM base AS main
 USER root
+
+RUN rm -rf /opt/puppetlabs/pdk/private/puppet/ruby/2.5.0/gems/httpclient-2.8.3/sample/ssl/* \
+  && rm -rf /opt/puppetlabs/pdk/private/ruby/2.5.9/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/sample/ssl/* \
+  && rm -rf /opt/puppetlabs/pdk/private/ruby/2.5.9/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/test/* \
+  && rm -rf /opt/puppetlabs/pdk/share/cache/ruby/2.7.0/gems/httpclient-2.8.3/sample/ssl/* \
+  && rm -rf /usr/local/bundle/gems/puppet-7.14.0/spec/fixtures/ssl/*


### PR DESCRIPTION
With this commit, we remove a handful of "sensitive" test files that are
left on disk as part of our Docker build process. These files don't pose
a real security threat, but the customer has requested we remove them,
and we have agreed.