### PR TITLE
Update README.md to reflect proper syntax for docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ You can use this container by running `docker run --rm -v $(pwd):/repo puppet/pu
    - run `docker run --rm puppet/puppet-dev-tools:4.x onceover --help` to see builtin help
    - see [Onceover's readme](https://github.com/dylanratcliffe/onceover/blob/master/README.md) for details
 3. Rake tasks from the installed gems (see below)
-   - run a single rake task like so: `docker run --rm -v $(pwd):/repo puppet/puppet-dev-tools:4.x rake lint`
-   - run multiple rake tasks sequentially like so: `docker run --rm -v $(pwd):/repo puppet/puppet-dev-tools:4.x rake lint syntax yamllint`
+   - run a single rake task like so: `docker run --rm -v $(pwd):/repo puppet/puppet-dev-tools:4.x rake -f /Rakefile lint`
+   - run multiple rake tasks sequentially like so: `docker run --rm -v $(pwd):/repo puppet/puppet-dev-tools:4.x rake -f /Rakefile lint syntax yamllint`
 
 ### A note on Onceover usage
 


### PR DESCRIPTION
This might not be the ultimate solution for why the docker container doesn't run properly; I'm not a developer.

Someone smarter than me can probably find the ultimate fix but changing the documentation so that the linter works is a short-term solution for guys like me that just want to check their puppet code.