### PR TITLE
Security updates alongside CD4PE 4.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get install -y apt-utils \
   && apt-get update -qq \
   && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends curl libxml2-dev libxslt1-dev g++ gcc git gnupg2 make openssh-client ruby-dev wget zlib1g-dev \
+  && apt-get install -y --no-install-recommends curl libxml2-dev libxslt1-dev g++ gcc git gnupg2 make openssh-client ruby-dev wget zlib1g-dev libldap-2.4-2 libldap-common libssl1.1 openssl \
   && wget https://apt.puppet.com/puppet-tools-release-buster.deb \
   && dpkg -i puppet-tools-release-buster.deb \
   && apt-get update -qq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN bundle config set system 'true' \
   && bundle config set jobs 3 \
   && bundle install \
   && rm -f /home/puppetdev/.bundle/config \
-  && rm -rf /usr/local/bundle/gems/puppet-7.*.0/spec/fixtures/ssl/*
+  && rm -rf /usr/local/bundle/gems/puppet-7.*.0/spec
 
 WORKDIR /repo
 


### PR DESCRIPTION
## (maint) Bump base image to 2.7-slim-buster

We were encountering a couple CVEs with the 2.7.4-slim-buster image (CVE-2022-29155, CVE-2022-1664, CVE-2022-1292, and CVE-2022-29824), all OS level issues. These could be patched by trying to upgrade each software individually, but upgrading the whole base image seemed like the easier and better decision (2.7.4-slim-buster is no longer 'supported'). c

----
## (maint) Expand puppet gem file removal

Trivy was tagging a few more files in the puppet gem spec directory as security risks. Instead of trying to pick out individual spec files, this just removes all the spec directories for puppet gems in the image.