### PR TITLE
(maint) Change Snyk key to SNYK_CD4PE_KEY

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,4 +19,4 @@ jobs:
       - name: run snyk
         run: snyk monitor --file=Gemfile.lock --project-name=${{github.repository}}:Gemfile.lock
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_FOSS_KEY }}
+          SNYK_TOKEN: ${{ secrets.SNYK_CD4PE_KEY }}


### PR DESCRIPTION
Currently, our snyk action reports to the foss project with the SNYK_FOSS_KEY but we want to see it in our snyk project, since we're the primary maintainers and it'll make visibility much better for us, so this commit changes the snyk command to use SNYK_CD4PE_KEY instead.