### PR TITLE
Add Trivy scans to github actions

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -13,6 +13,14 @@ jobs:
         run: ./build-rootless.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
       - name: Build standard image
         run: ./build.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: puppet-dev-tools:latest
+          exit-code: 1
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          vuln-type: os
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images

--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -13,20 +13,32 @@ on:
 jobs:
   publish-4x-image:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
     steps:
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
-      - name: Publish standard image to 4.x
+      - name: Pull image
         env:
-          IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}
         run: |
           docker pull ${IMAGE_BASE}:${IMAGE_TAG}
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_BASE }}:${{ github.event.inputs.image_tag }}
+          exit-code: 1
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          vuln-type: os
+      - name: Publish standard image to 4.x
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
           docker tag ${IMAGE_BASE}:${IMAGE_TAG} ${IMAGE_BASE}:4.x
           docker push ${IMAGE_BASE}:4.x
       - name: Publish rootless image to 4.x-rootless
         env:
-          IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
           IMAGE_TAG: ${{ github.event.inputs.image_tag_rootless }}
         run: |
           docker pull ${IMAGE_BASE}:${IMAGE_TAG}


### PR DESCRIPTION
## (maint) Add Trivy scan to build-test-push

Trivy is our official container scanning solution now, so this adds a
trivy scan whenever we try to push a new puppet-dev-tools container so
we don't release containers with unwanted vulnerabilities.
Trivy only scans the root-based image to save time as there are no
os-level differences between root and rootless images.

----
## (maint) Add Trivy to 4.x publish

This adds a Trivy scan to the 4.x publish action. Since vulnerabilities
can be discovered at any time, we want to double check the dev image before we
publish to 4.x. As part of adding the Trivy step, this also splits out
the docker pull part of the action, which saves time on the Trivy scan that was timing out.