### PR TITLE
(maint) bump Trivy scan timeout in Build-Test-Push action

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -21,6 +21,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
+          timeout: 10m0s
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images

--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -31,6 +31,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
+          timeout: 10m0s
       - name: Publish standard image to 4.x
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
Adds a timeout of 10 minutes (default is 5 min) to get around transient timeout failures