### PR TITLE
(maint) pin PDK version to 2.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install -y apt-utils \
   && wget https://apt.puppet.com/puppet-tools-release-buster.deb \
   && dpkg -i puppet-tools-release-buster.deb \
   && apt-get update -qq \
-  && apt-get install -y --no-install-recommends pdk \
+  && apt-get install -y --no-install-recommends pdk=2.7.1.0-1buster \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /opt/puppetlabs/pdk/private/puppet/ruby/2.5.0/gems/httpclient-2.8.3/sample/ssl/* \


### PR DESCRIPTION
We don't want to release PDK 3.0.0 yet in puppet-dev-tools, so to prevent automatic upgrades with our build process, this change pins the PDK version to the current 2.x version.