### PR TITLE
(maint) Pin bundler to 2.4.22, which supports Ruby 2.7.4

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -22,7 +22,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
-          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml"
+          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml,/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -22,6 +22,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
+          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml"
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,6 +24,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
+          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml"
       - name: Run tests
         working-directory: ${{ github.workspace }}/tests
         run: ./run_tests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
-          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml"
+          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml,/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
       - name: Run tests
         working-directory: ${{ github.workspace }}/tests
         run: ./run_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN groupadd --gid 1001 puppetdev \
   && useradd --uid 1001 --gid puppetdev --create-home puppetdev
 
 # Prep for non-root user
-RUN gem install bundler \
+RUN gem install bundler -v 2.4.22 \
   && chown -R puppetdev:puppetdev /usr/local/bundle \
   && mkdir /setup \
   && chown -R puppetdev:puppetdev /setup \


### PR DESCRIPTION
We currently pin our Ruby version in this Dockerfile to 2.7.4, so we also need to pin bundler to a version compatible with that. Updating the Ruby version is a bigger project that would need to be looked into separately.