### PR TITLE
(maint) Update file skips for trivy

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -22,7 +22,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
-          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml,/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
+          skip-files: "/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
-          skip-files: "/usr/local/bundle/gems/nokogiri-1.15.5-x86_64-linux/dependencies.yml,/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
+          skip-files: "/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
       - name: Run tests
         working-directory: ${{ github.workspace }}/tests
         run: ./run_tests.sh

--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -32,6 +32,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           vuln-type: os
           timeout: 10m0s
+          skip-files: "/root/.pdk/cache/ruby/2.5.0/gems/aws-sdk-core-3.191.0/lib/aws-sdk-ssooidc/client.rb"
       - name: Publish standard image to 4.x
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
Add a file skip to the publish job, remove the nokogiri skip as it appears to no longer be needed.