### PR TITLE
(CDPE-6528) Make Build-Test job callable

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 name: Build-Test
+
 on:
-  - pull_request
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   Build-Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So we can invoke it from our release automation in PipelinesInfra.