### PR TITLE
(CDPE-6528) Input image tag name to Build-Test-Push

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -1,9 +1,15 @@
 name: Build-Test-Push
+
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional tag to create in addition to the `latest` and `<timestamp>-<sha>` image tags.
+        required: false
   push:
     branches:
       - main
+
 jobs:
   Build-Test-Push:
     runs-on: ubuntu-latest
@@ -29,6 +35,11 @@ jobs:
         run: |
           docker tag puppet-dev-tools:latest-rootless ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)-rootless
           docker tag puppet-dev-tools:latest ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)
+      - name: Additional Tag
+        if: inputs.tag
+        run: |
+          docker tag puppet-dev-tools:latest-rootless ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:${{ inputs.tag }}-rootless
+          docker tag puppet-dev-tools:latest ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:${{ inputs.tag }}
       - name: List Docker images
         run: docker images --filter "reference=puppet-dev-tools*" --filter "reference=*/puppet-dev-tools*"
       - name: Show Docker image labels
@@ -40,3 +51,8 @@ jobs:
         run: |
           docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)-rootless
           docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)
+      - name: Push Additional Tag
+        if: inputs.tag
+        run: |
+          docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:${{ inputs.tag }}-rootless
+          docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:${{ inputs.tag }}


### PR DESCRIPTION
Add optional input to the Build-Test-Push job for supplying an image tag to create in addition to the latest and timestamp-sha tags.

This enables workflows to call this and reliable know the name of the resulting image, and is a result of that fact that GitHub does not have a native way to run a workflow on a remote repository and get some sort of string-like output from it.

Since there's no way to get data back from the called workflow, instead let the calling workflow decide what name to use for the image tag.

Overall this enables this workflow to be called in automation by the CD4PE release workflows so the developer doing the CD4PE release doesn't have to manually trigger this first, find the image tag it created, then supply that image tag to a different workflow.