### PR TITLE
(maint) Temporarily disable trivy scans due to rate limiting

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -19,16 +19,6 @@ jobs:
         run: ./build-rootless.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
       - name: Build standard image
         run: ./build.sh $(echo $GITHUB_REPOSITORY |cut -d '/' -f1)
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: puppet-dev-tools:latest
-          exit-code: 1
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          vuln-type: os
-          timeout: 10m0s
-          skip-files: "/root/.pdk/cache/ruby/*/gems/aws-sdk-core-*/lib/aws-sdk-ssooidc/client.rb"
       - name: Run tests
         run: cd tests; ./run_tests.sh
       - name: Tag Docker images

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,16 +18,6 @@ jobs:
       - name: Show Docker image labels
         run: |
           docker inspect --format='{{json .Config.Labels}}' ${{ secrets.DOCKERHUB_USERNAME }}/puppet-dev-tools
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: puppet-dev-tools:latest
-          exit-code: 1
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          vuln-type: os
-          timeout: 10m0s
-          skip-files: "/root/.pdk/cache/ruby/*/gems/aws-sdk-core-*/lib/aws-sdk-ssooidc/client.rb"
       - name: Run tests
         working-directory: ${{ github.workspace }}/tests
         run: ./run_tests.sh

--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -23,16 +23,6 @@ jobs:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}
         run: |
           docker pull ${IMAGE_BASE}:${IMAGE_TAG}
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.IMAGE_BASE }}:${{ github.event.inputs.image_tag }}
-          exit-code: 1
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          vuln-type: os
-          timeout: 10m0s
-          skip-files: "/root/.pdk/cache/ruby/*/gems/aws-sdk-core-*/lib/aws-sdk-ssooidc/client.rb"
       - name: Publish standard image to 4.x
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
The Trivy github action is currently experiencing a GCR rating limiting issue pulling its vulnerability DB
(https://github.com/aquasecurity/trivy-action/issues/389).  Until that issue is resolved, or we work out a way to host it ourselves, this commit will disable the scans.

In the meantime, we will have to run these scans manually.