### PR TITLE
(CDPE-7069) Start caching trivy DBs in separate workflow

### DIFF
--- a/.github/workflows/update-trivy-cache.yml
+++ b/.github/workflows/update-trivy-cache.yml
@@ -1,0 +1,43 @@
+# https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#updating-caches-in-the-default-branch
+# This workflow is needed to get around rate limiting on ghcr. This will update the trivy DBs in the
+# github cache to allow the trivy scans themselves to run without pulling the DB.  This will allow the
+# scans to run without running into rate limit issues.  This workflow could run into those issues when
+# downloading the cache, but as long as it succeeds more often than it fails, we will have our bases
+# covered.
+name: Update Trivy DB Caches
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 2 * * *' # Daily at random time (2:17am UTC)
+
+jobs:
+  update-caches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
In order to avoid ratelimiting issues when running trivy scans, all trivy runs need to run against a local copy of the DB (rather than downloading it each time). This commit adds a workflow to download the trivy DBs each morning.

Once this is in place and runs at least once, the trivy scans can be added back in and set to use the cache rather than download.

This PR is essentially following the documented steps at https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#updating-caches-in-the-default-branch