### PR TITLE
Use EXCLUDE_PATHS in yamllint task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,7 @@ PuppetSyntax.hieradata_paths = ps_hieradata_paths
 
 YamlLint::RakeTask.new do |yamllint|
   yamllint.paths = yl_paths
+  yamllint.exclude_paths = exclude_paths
 end
 
 Rake::Task[:spec_prep].enhance [:generate_fixtures]


### PR DESCRIPTION
This allows users to set exclude paths for yamllint via the environment variable `EXCLUDE_PATHS`.

See: https://github.com/shortdudey123/yamllint?tab=readme-ov-file#rake-task-options

