### PR TITLE
 (maint) Update GH actions to use DOCKERHUB_TOKEN

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           docker inspect --format='{{json .Config.Labels}}' ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)
       - name: Login to Docker Hub
-        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
       - name: Push Docker images
         run: |
           docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)-rootless

--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -17,7 +17,7 @@ jobs:
       IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
     steps:
       - name: Login to Docker Hub
-        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
       - name: Pull image
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
IT just blessed us with an OAT that will allow us to push to puppet/puppet-dev-tools on dockerhub again. This switches our actions over to use the token instead of our password per dockerhubs docs here https://docs.docker.com/security/for-admins/access-tokens/#use-an-organization-access-token