### PR TITLE
(maint) use DOCKERHUB_PUSH_USERNAME with token

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           docker inspect --format='{{json .Config.Labels}}' ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)
       - name: Login to Docker Hub
-        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_PUSH_USERNAME }} --password-stdin
       - name: Push Docker images
         run: |
           docker push ${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools:$(date +"%F")-$(git rev-parse --short HEAD)-rootless

--- a/.github/workflows/publish-4x-image.yml
+++ b/.github/workflows/publish-4x-image.yml
@@ -17,7 +17,7 @@ jobs:
       IMAGE_BASE: "${{ secrets.DOCKERHUB_PUSH_USERNAME }}/puppet-dev-tools"
     steps:
       - name: Login to Docker Hub
-        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_LOGIN_USERNAME }} --password-stdin
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_PUSH_USERNAME }} --password-stdin
       - name: Pull image
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
I made a boo boo, it didn't occur to me to test the changes from the last commit before i merged them. Anynway, we merged in using the new DOCKERHUB_TOKEN but did not change the username to 'puppet'. This makes that change. It is an org token that needs to be used with the org name.