### PR TITLE
Revert "(maint) Add step to mend scan GHA to report any vulns found"

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - puppet8
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,12 +37,3 @@ jobs:
         WS_USERKEY: ${{ secrets.MEND_TOKEN }}
         WS_PRODUCTNAME: CD4PE
         WS_PROJECTNAME:  ${{ github.event.repository.name }}
-    - name: "report vulnerabilities"
-        id: vulnerabilities
-        uses: puppetlabs/get-mend-vulnerabilities@v2
-        with:
-          product_token: ${{ secrets.MEND_PRODUCT_TOKEN }}
-          product_display_name: "CD4PE"
-          user_token: ${{ secrets.MEND_TOKEN }}
-          fail_on_alert: "true"
-          projects: "puppet-dev-tools"


### PR DESCRIPTION
This reverts commit 9089dce48b612feb8e1170f51f30cfe84a1f1ebf.

The action used in this step isn't available from public repos, and running this job against the `puppet8` branch will require some additional work.